### PR TITLE
Handle volatile memory access

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -4792,7 +4792,7 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
 
 void CWriter::writeMemoryAccess(Value *Operand, Type *OperandType,
                                 bool IsVolatile, unsigned Alignment /*bytes*/) {
-  if (isAddressExposed(Operand)) {
+  if (isAddressExposed(Operand) && !IsVolatile) {
     writeOperandInternal(Operand);
     return;
   }
@@ -4800,9 +4800,14 @@ void CWriter::writeMemoryAccess(Value *Operand, Type *OperandType,
   bool IsUnaligned =
       Alignment && Alignment < TD->getABITypeAlignment(OperandType);
 
-  if (!IsUnaligned)
+  if (!IsUnaligned) {
     Out << '*';
-
+    if (IsVolatile) {
+        Out << "(volatile ";
+        printTypeName(Out, OperandType, false);
+        Out << "*)";
+      }
+  }
   else if (IsUnaligned) {
     Out << "__UNALIGNED_LOAD__(";
     printTypeNameUnaligned(Out, OperandType, false);
@@ -4811,12 +4816,6 @@ void CWriter::writeMemoryAccess(Value *Operand, Type *OperandType,
     Out << ", " << Alignment << ", ";
   }
 
-  else if (IsVolatile) {
-    Out << "(";
-    printTypeName(Out, OperandType, false);
-    Out << "volatile";
-    Out << "*)";
-  }
 
   writeOperand(Operand);
 

--- a/test/c_tests/declarations/test_declare_volatile_unsigned_int.c
+++ b/test/c_tests/declarations/test_declare_volatile_unsigned_int.c
@@ -1,0 +1,18 @@
+//===---------------------- LLVM C Backend test file ----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This code tests to see that the CBE can handle volatile integers
+//
+//===----------------------------------------------------------------------===//
+
+int main() {
+  volatile unsigned int a = 6;
+  return a;
+}
+


### PR DESCRIPTION
Currently volatile memory access is not handled correctly, because writeOpernadInternal does not handle volatile and there code to print a cast to volatile is never reached. This should fix this problem