### PR TITLE
Add Docker image and example using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@ RUN \
   mkdir -p /root/llvm/build; \
   cd /root/llvm/build; \
   cmake ..; \
-  make; \
-  cd /root/llvm/projects; \
-  git clone https://github.com/JuliaComputing/llvm-cbe; \
+  make;
+
+COPY . /root/llvm/projects/llvm-cbe/
+
+RUN \
+  set -e; \
   cd /root/llvm/projects/llvm-cbe; \
   git reset 45a5de1bb25e0d9bb7fea50100deab829f194c9a --hard; \
   cd /root/llvm/build; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,25 @@ RUN \
   wget -qO- "https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz" \
     | tar --strip-components=1 -xz -C /usr/local; \
   cd /root; \
-  git clone https://github.com/llvm-mirror/llvm; \
-  cd /root/llvm; \
-  git checkout release_70; \
-  mkdir -p /root/llvm/build; \
-  cd /root/llvm/build; \
-  cmake ..; \
-  make;
+  curl -fLO https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip; \
+  unzip /root/ninja-linux.zip; \
+  rm /root/ninja-linux.zip; \
+  mv /root/ninja /bin/ninja; \
+  chmod +x /bin/ninja; \
+  curl -fL http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz \
+    | tar xJf -; \
+  mv /root/llvm-7.0.1.src /root/llvm; \
+  mkdir -p /root/llvm/build;
 
 COPY . /root/llvm/projects/llvm-cbe/
 
 RUN \
   set -e; \
-  cd /root/llvm/projects/llvm-cbe; \
-  git reset 45a5de1bb25e0d9bb7fea50100deab829f194c9a --hard; \
+  mkdir -p /root/llvm/build; \
   cd /root/llvm/build; \
-  cmake ..; \
-  make llvm-cbe; \
-  make lli; \
-  make CBEUnitTests; \
+  cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..; \
+  ninja llvm-cbe; \
+  ninja lli; \
+  ninja CBEUnitTests; \
   /root/llvm/build/projects/llvm-cbe/unittests/CWriterTest; \
   ln -s /root/llvm/build/bin/llvm-cbe /bin/llvm-cbe;

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ RUN \
   set -e; \
   apt update && apt install -y \
     clang \
-    ninja-build; \
-  wget -qO- "https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz" \
-    | tar --strip-components=1 -xz -C /usr/local; \
+    ninja-build \
+    cmake; \
   cd /root; \
   curl -fL http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz \
     | tar xJf -; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM buildpack-deps:stretch
 
 RUN \
   set -e; \
-  apt update && apt install -y clang; \
+  apt update && apt install -y \
+    clang \
+    ninja-build; \
   wget -qO- "https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz" \
     | tar --strip-components=1 -xz -C /usr/local; \
   cd /root; \
-  curl -fLO https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip; \
-  unzip /root/ninja-linux.zip; \
-  rm /root/ninja-linux.zip; \
-  mv /root/ninja /bin/ninja; \
-  chmod +x /bin/ninja; \
   curl -fL http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz \
     | tar xJf -; \
   mv /root/llvm-7.0.1.src /root/llvm; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ RUN \
   make llvm-cbe; \
   make lli; \
   make CBEUnitTests; \
-  /root/llvm/build/projects/llvm-cbe/unittests/CWriterTest;
+  /root/llvm/build/projects/llvm-cbe/unittests/CWriterTest; \
+  ln -s /root/llvm/build/bin/llvm-cbe /bin/llvm-cbe;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM buildpack-deps:stretch
+
+RUN \
+  set -e; \
+  apt update && apt install -y clang; \
+  wget -qO- "https://cmake.org/files/v3.13/cmake-3.13.1-Linux-x86_64.tar.gz" \
+    | tar --strip-components=1 -xz -C /usr/local; \
+  cd /root; \
+  git clone https://github.com/llvm-mirror/llvm; \
+  cd /root/llvm; \
+  git checkout release_70; \
+  mkdir -p /root/llvm/build; \
+  cd /root/llvm/build; \
+  cmake ..; \
+  make; \
+  cd /root/llvm/projects; \
+  git clone https://github.com/JuliaComputing/llvm-cbe; \
+  cd /root/llvm/projects/llvm-cbe; \
+  git reset 45a5de1bb25e0d9bb7fea50100deab829f194c9a --hard; \
+  cd /root/llvm/build; \
+  cmake ..; \
+  make llvm-cbe; \
+  make lli; \
+  make CBEUnitTests; \
+  /root/llvm/build/projects/llvm-cbe/unittests/CWriterTest;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  llvm-cde:
+  llvm-cbe:
     build: .
     working_dir: /root
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+  llvm-cde:
+    build: .
+    working_dir: /root
+    command: |
+      bash -c "
+        set -e;
+        cd /root/llvm/projects/llvm-cbe/test/selectionsort;
+
+        echo '# Logging initial files';
+        ls;
+
+        clang -S -emit-llvm main.c;
+        echo '# Logging compiled files';
+        ls;
+
+        /root/llvm/build/bin/llvm-cbe main.ll;
+        gcc -g -o main.cbe main.cbe.c;
+        echo '# Logging files compiled to C';
+        ls;
+
+        echo '# Running files compiled from code compiled to C';
+        ./main.cbe;
+      "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,23 +4,24 @@ services:
   llvm-cde:
     build: .
     working_dir: /root
+    volumes:
+      - ./test:/test
     command: |
       bash -c "
         set -e;
-        cd /root/llvm/projects/llvm-cbe/test/selectionsort;
 
-        echo '# Logging initial files';
-        ls;
+        # Navigate to test folder
+        cd /test/hello_world;
 
+        # Compile main.c to llvm IR
         clang -S -emit-llvm main.c;
-        echo '# Logging compiled files';
-        ls;
 
+        # Compile llvm IR back to C
         /root/llvm/build/bin/llvm-cbe main.ll;
-        gcc -g -o main.cbe main.cbe.c;
-        echo '# Logging files compiled to C';
-        ls;
 
-        echo '# Running files compiled from code compiled to C';
+        # Compile llvm-cbe generated C code
+        gcc -g -o main.cbe main.cbe.c;
+
+        # Run it
         ./main.cbe;
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         clang -S -emit-llvm main.c;
 
         # Compile llvm IR back to C
-        /root/llvm/build/bin/llvm-cbe main.ll;
+        llvm-cbe main.ll;
 
         # Compile llvm-cbe generated C code
         gcc -g -o main.cbe main.cbe.c;

--- a/test/hello_world/.gitignore
+++ b/test/hello_world/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!main.c

--- a/test/hello_world/main.c
+++ b/test/hello_world/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+   printf("Hello, World!");
+   return 0;
+}

--- a/test/hello_world/main.c
+++ b/test/hello_world/main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
 int main() {
-   printf("Hello, World!");
+   printf("Hello, World!\n");
    return 0;
 }


### PR DESCRIPTION
This strings together all the documentation for setup, building, testing of llvm-cbe and how to use it. Using Docker will make llvm-cbe more portable and easier for folks to use.