### PR TITLE
Add support for atomic operations and change CTargetMachine from Targ…

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -23,9 +23,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/TargetRegistry.h"
 
-#if LLVM_VERSION_MAJOR >= 7
-#include "llvm/Transforms/Utils.h"
-#endif
+
 
 #include <algorithm>
 #include <cstdio>
@@ -5021,34 +5019,4 @@ LLVM_ATTRIBUTE_NORETURN void CWriter::errorWithMessage(const char *message) {
 
 } // namespace llvm_cbe
 
-//===----------------------------------------------------------------------===//
-//                       External Interface declaration
-//===----------------------------------------------------------------------===//
 
-namespace llvm {
-
-bool CTargetMachine::addPassesToEmitFile(PassManagerBase &PM,
-                                         raw_pwrite_stream &Out,
-#if LLVM_VERSION_MAJOR >= 7
-                                         raw_pwrite_stream *DwoOut,
-#endif
-                                         CodeGenFileType FileType,
-                                         bool DisableVerify,
-                                         MachineModuleInfo *MMI) {
-
-  if (FileType != TargetMachine::CGFT_AssemblyFile)
-    return true;
-
-  PM.add(createGCLoweringPass());
-
-  // Remove exception handling with LowerInvokePass. This would be done with
-  // TargetPassConfig if TargetPassConfig supported TargetMachines that aren't
-  // LLVMTargetMachines.
-  PM.add(createLowerInvokePass());
-  PM.add(createUnreachableBlockEliminationPass());
-
-  PM.add(new llvm_cbe::CWriter(Out));
-  return false;
-}
-
-} // namespace llvm

--- a/lib/Target/CBackend/CMakeLists.txt
+++ b/lib/Target/CBackend/CMakeLists.txt
@@ -14,4 +14,5 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_target(CBackendCodeGen
   CBackend.cpp
+  CTargetMachine.cpp
   )

--- a/lib/Target/CBackend/CTargetMachine.cpp
+++ b/lib/Target/CBackend/CTargetMachine.cpp
@@ -1,0 +1,63 @@
+//===-- CTargetMachine.cpp - TargetMachine for the C backend ----*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the TargetMachine that is used by the C backend.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CTargetMachine.h"
+#include "CBackend.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
+
+#if LLVM_VERSION_MAJOR >= 7
+#include "llvm/Transforms/Utils.h"
+#endif
+
+namespace llvm {
+
+bool CTargetMachine::addPassesToEmitFile(PassManagerBase &PM,
+                                         raw_pwrite_stream &Out,
+#if LLVM_VERSION_MAJOR >= 7
+                                         raw_pwrite_stream *DwoOut,
+#endif
+                                         CodeGenFileType FileType,
+                                         bool DisableVerify,
+                                         MachineModuleInfo *MMI) {
+
+  if (FileType != TargetMachine::CGFT_AssemblyFile)
+    return true;
+
+  PM.add(new TargetPassConfig(*this, PM));
+  PM.add(createGCLoweringPass());
+
+  // Remove exception handling with LowerInvokePass. This would be done with
+  // TargetPassConfig if TargetPassConfig supported TargetMachines that aren't
+  // LLVMTargetMachines.
+  PM.add(createLowerInvokePass());
+  PM.add(createUnreachableBlockEliminationPass());
+
+  // Lower atomic operations to libcalls
+  PM.add(createAtomicExpandPass());
+
+  PM.add(new llvm_cbe::CWriter(Out));
+  return false;
+}
+
+const TargetSubtargetInfo *
+CTargetMachine::getSubtargetImpl(const Function &) const {
+  return &SubtargetInfo;
+}
+
+bool CTargetSubtargetInfo::enableAtomicExpand() const { return true; }
+
+const TargetLowering *CTargetSubtargetInfo::getTargetLowering() const {
+  return &Lowering;
+}
+
+} // namespace llvm

--- a/test/c_tests/stdatomic/test_atomic_compare_exchange_strong.c
+++ b/test/c_tests/stdatomic/test_atomic_compare_exchange_strong.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   int y = 1;

--- a/test/c_tests/stdatomic/test_atomic_compare_exchange_weak.c
+++ b/test/c_tests/stdatomic/test_atomic_compare_exchange_weak.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   int y = 1;

--- a/test/c_tests/stdatomic/test_atomic_exchange.c
+++ b/test/c_tests/stdatomic/test_atomic_exchange.c
@@ -1,6 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
 
 int main() {
   atomic_int x = 0;

--- a/test/c_tests/stdatomic/test_atomic_fetch_add.c
+++ b/test/c_tests/stdatomic/test_atomic_fetch_add.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   atomic_fetch_add(&x, 3);

--- a/test/c_tests/stdatomic/test_atomic_fetch_and.c
+++ b/test/c_tests/stdatomic/test_atomic_fetch_and.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0b1111;
   atomic_fetch_and(&x, 0b1110);

--- a/test/c_tests/stdatomic/test_atomic_fetch_or.c
+++ b/test/c_tests/stdatomic/test_atomic_fetch_or.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   atomic_fetch_or(&x, 2);

--- a/test/c_tests/stdatomic/test_atomic_fetch_sub.c
+++ b/test/c_tests/stdatomic/test_atomic_fetch_sub.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 12;
   atomic_fetch_sub(&x, 3);

--- a/test/c_tests/stdatomic/test_atomic_fetch_xor.c
+++ b/test/c_tests/stdatomic/test_atomic_fetch_xor.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   atomic_fetch_xor(&x, 7);

--- a/test/c_tests/stdatomic/test_atomic_load.c
+++ b/test/c_tests/stdatomic/test_atomic_load.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 6;
   return atomic_load(&x);

--- a/test/c_tests/stdatomic/test_atomic_store.c
+++ b/test/c_tests/stdatomic/test_atomic_store.c
@@ -1,7 +1,5 @@
 #include <stdatomic.h>
 
-// xfail: no atomic support (#10)
-
 int main() {
   atomic_int x = 0;
   atomic_store(&x, 6);

--- a/test/test_cbe.py
+++ b/test/test_cbe.py
@@ -34,6 +34,9 @@ GCC = 'gcc'
 GCCFLAGS = COMMON_CFLAGS + [
     '-Wno-error=unused-but-set-variable',
     '-Wno-unused-but-set-variable',
+    '-Wno-builtin-declaration-mismatch',
+    '-Wno-error=builtin-declaration-mismatch',
+    '-latomic',
 ]
 
 CLANG = 'clang'


### PR DESCRIPTION
…etMachine to LLVMTargetMachine

Support for atomic operations is done with the llvm atomicExpandPass. This pass lowers atomic operations to calls into libatomic.

This should fix  #10