### PR TITLE
Use Topological Sorting for function typedefs.

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3139,13 +3139,6 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
     }
   }
 
-  Out << "\n/* Types Definitions */\n";
-
-  for (auto it = TypedefDeclTypes.begin(), end = TypedefDeclTypes.end();
-       it != end; ++it) {
-    printContainedTypes(Out, *it, TypesPrinted);
-  }
-
   Out << "\n/* Function definitions */\n";
 
   struct FunctionDefinition {
@@ -3205,6 +3198,15 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
     printFunctionProto(Out, F);
     Out << ";\n";
   }
+
+  Out << "\n/* Types Definitions */\n";
+
+  for (auto it = TypedefDeclTypes.begin(), end = TypedefDeclTypes.end();
+       it != end; ++it) {
+    printContainedTypes(Out, *it, TypesPrinted);
+  }
+
+
 }
 
 void CWriter::forwardDeclareStructs(raw_ostream &Out, Type *Ty,

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3139,7 +3139,6 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
     }
   }
 
-
   Out << "\n/* Types Definitions */\n";
 
   for (auto it = TypedefDeclTypes.begin(), end = TypedefDeclTypes.end();
@@ -3151,11 +3150,7 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
 
   for (auto &I : UnnamedFunctionIDs) {
     Out << '\n';
-    std::pair<FunctionType *, std::pair<AttributeList, CallingConv::ID>> F =
-        I.first;
-    if (F.second.first.isEmpty() && F.second.second == CallingConv::C)
-      if (!TypesPrinted.insert(F.first).second)
-        continue; // already printed this above
+    const auto &F = I.first;
     printFunctionDeclaration(Out, F.first, F.second);
   }
 
@@ -3183,7 +3178,6 @@ void CWriter::forwardDeclareStructs(raw_ostream &Out, Type *Ty,
     Out << getStructName(ST) << ";\n";
   }
 }
-
 
 // Push the struct onto the stack and recursively push all structs
 // this one depends on.

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3139,15 +3139,6 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
     }
   }
 
-  // forward-declare all function pointer typedefs (Issue #2)
-
-  {
-    std::set<Type *> TypesPrinted;
-    for (auto it = TypedefDeclTypes.begin(), end = TypedefDeclTypes.end();
-         it != end; ++it) {
-      forwardDeclareFunctionTypedefs(Out, *it, TypesPrinted);
-    }
-  }
 
   Out << "\n/* Types Definitions */\n";
 
@@ -3193,21 +3184,6 @@ void CWriter::forwardDeclareStructs(raw_ostream &Out, Type *Ty,
   }
 }
 
-void CWriter::forwardDeclareFunctionTypedefs(raw_ostream &Out, Type *Ty,
-                                             std::set<Type *> &TypesPrinted) {
-  if (!TypesPrinted.insert(Ty).second)
-    return;
-  if (isEmptyType(Ty))
-    return;
-
-  for (auto I = Ty->subtype_begin(); I != Ty->subtype_end(); ++I) {
-    forwardDeclareFunctionTypedefs(Out, *I, TypesPrinted);
-  }
-
-  if (FunctionType *FT = dyn_cast<FunctionType>(Ty)) {
-    printFunctionDeclaration(Out, FT);
-  }
-}
 
 // Push the struct onto the stack and recursively push all structs
 // this one depends on.

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -106,8 +106,6 @@ private:
 
   void forwardDeclareStructs(raw_ostream &Out, Type *Ty,
                              std::set<Type *> &TypesPrinted);
-  void forwardDeclareFunctionTypedefs(raw_ostream &Out, Type *Ty,
-                                      std::set<Type *> &TypesPrinted);
 
   raw_ostream &printFunctionAttributes(raw_ostream &Out, AttributeList Attrs);
 

--- a/lib/Target/CBackend/CMakeLists.txt
+++ b/lib/Target/CBackend/CMakeLists.txt
@@ -15,4 +15,5 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_target(CBackendCodeGen
   CBackend.cpp
   CTargetMachine.cpp
+  TopologicalSorter.cpp
   )

--- a/lib/Target/CBackend/TopologicalSorter.cpp
+++ b/lib/Target/CBackend/TopologicalSorter.cpp
@@ -1,0 +1,56 @@
+//===------------------ TopologicalSorter.cpp--------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a DFS based Topological Sorter to order dependencies in
+// the C Backend
+//
+//===----------------------------------------------------------------------===//
+#include "TopologicalSorter.h"
+
+namespace llvm_cbe {
+
+void TopologicalSorter::addEdge(int Start, int End) {
+  AdjacencyMatrix[Start].push_back(End);
+}
+
+TopologicalSorter::TopologicalSorter(int Size) {
+  this->Size = Size;
+  AdjacencyMatrix.resize(Size);
+  Marks.resize(Size, Mark::Unvisited);
+  Result.reserve(Size);
+}
+
+llvm::Optional<std::vector<int>> TopologicalSorter::sort() {
+  for (int I = 0; I < Size; ++I) {
+    if (visit(I)) {
+      return llvm::None;
+    }
+  }
+  return Result;
+}
+
+bool TopologicalSorter::visit(int Node) {
+  if (Marks[Node] == Mark::Permanent) {
+    return false;
+  }
+  if (Marks[Node] == Mark::Temp) { // Cycle
+    return true;
+  }
+  Marks[Node] = Mark::Temp;
+  for (const int I : AdjacencyMatrix[Node]) {
+    if (visit(I)) {
+      return true;
+    }
+  }
+  Marks[Node] = Mark::Permanent;
+  Result.push_back(Node);
+  return false;
+}
+
+} // namespace llvm_cbe

--- a/lib/Target/CBackend/TopologicalSorter.h
+++ b/lib/Target/CBackend/TopologicalSorter.h
@@ -1,0 +1,43 @@
+//===------------------ TopologicalSorter.h----------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares a DFS based Topological Sorter to order dependencies in
+// the C Backend
+//
+//===----------------------------------------------------------------------===//
+#ifndef TOPOLOGICALSORTER_H
+#define TOPOLOGICALSORTER_H
+
+#include <llvm/ADT/Optional.h>
+#include <vector>
+
+namespace llvm_cbe {
+
+class TopologicalSorter {
+  int Size;
+  std::vector<std::vector<int>> AdjacencyMatrix;
+  enum class Mark {
+    Unvisited,
+    Temp,
+    Permanent,
+  };
+  std::vector<Mark> Marks;
+  std::vector<int> Result;
+  bool visit(int Node); // Returns true on cycle detection
+
+public:
+  explicit TopologicalSorter(int Size);
+
+  void addEdge(int Start, int End);
+  llvm::Optional<std::vector<int>> sort(); // Returns None if there are cycles
+};
+
+} // namespace llvm_cbe
+
+#endif // TOPOLOGICALSORTER_H

--- a/test/c_tests/functions/test_casted_nested_function_ptr_argument.c
+++ b/test/c_tests/functions/test_casted_nested_function_ptr_argument.c
@@ -12,9 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// xfail: function pointer typedefs are sometimes in the wrong order (fails
-// inconsistently)
-
 static int return_arg(int x) { return x; }
 
 static int call1(void *f, int x) { return ((int (*)(int))f)(x); }

--- a/test/ll_tests/test_compile_opaque_struct_with_function.ll
+++ b/test/ll_tests/test_compile_opaque_struct_with_function.ll
@@ -1,0 +1,16 @@
+%TOpaque = type opaque
+%TReal = type { i32 (%TOpaque*) *} 
+
+; Function Attrs: nounwind uwtable
+define i32 @call4(%TOpaque*) unnamed_addr {
+  %bcast = bitcast %TOpaque* %0 to %TReal*
+  %2 = getelementptr %TReal, %TReal* %bcast, i32 0, i32 0
+  %3 = load i32 (%TOpaque*) *, i32 (%TOpaque*) ** %2
+  %4 = call i32 %3(%TOpaque* %0)
+  ret i32 %4
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  ret i32 6
+}


### PR DESCRIPTION
This prevents errors caused by a wrong ordering of functions which take a function pointer as argument