### PR TITLE
Correct omissions and typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,8 @@ Next, download and compile llvm-cbe from the same folder:
     cd $HOME/llvm/projects
     git clone https://github.com/JuliaComputing/llvm-cbe
     cd ../build
+    cmake ..
     make llvm-cbe
-
-To run tests, you will also need to build `lli`:
-
-```sh
-    make lli
-```
 
 To run tests, you will also need to build `lli`:
 


### PR DESCRIPTION
Hi,

I corrected a couple of minor things in the README:
- Add a missing step in Step 2 - CMake must be run again after cloning llvm-cbe
- Remove duplicate instructions to make lli