### PR TITLE
Add reference macro to generated c output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The first step is to compile LLVM on your machine
      cd $HOME
      git clone https://github.com/llvm/llvm-project.git
      cd llvm-project
-     git checkout release_80
+     git checkout release/8.x
      mkdir llvm/build
      cd llvm/build
      cmake ..
@@ -62,7 +62,7 @@ If llvm-cbe compiles, you should be able to run it with the following commands.
 $ cd $HOME/llvm-project/llvm/projects/llvm-cbe/test/selectionsort
 $ ls
 main.c
-$ clang -S -emit-llvm main.c
+$ clang -S -emit-llvm -g main.c
 $ ls
 main.c main.ll
 $ $(HOME)/llvm/build/bin/llvm-cbe main.ll

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Config/config.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/PatternMatch.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Host.h"
@@ -3572,6 +3573,11 @@ void CWriter::printBasicBlock(BasicBlock *BB) {
 
   // Output all of the instructions in the basic block...
   for (BasicBlock::iterator II = BB->begin(), E = --BB->end(); II != E; ++II) {
+    DILocation *Loc = (*II).getDebugLoc();
+    if (Loc != nullptr && LastAnnotatedSourceLine != Loc->getLine()) {
+      Out << "#line " << Loc->getLine() << " \"" << Loc->getDirectory() << "/" << Loc->getFilename() << "\"" << "\n";
+      LastAnnotatedSourceLine = Loc->getLine();
+    }
     if (!isInlinableInst(*II) && !isDirectAlloca(&*II)) {
       if (!isEmptyType(II->getType()) && !isInlineAsm(*II))
         outputLValue(&*II);

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -88,6 +88,8 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
   // will only be expanded on first use
   std::vector<Function *> prototypesToGen;
 
+  unsigned LastAnnotatedSourceLine = 0;
+
   struct {
     bool BuiltinAlloca : 1;
     bool Unreachable : 1;


### PR DESCRIPTION
Usefull for debugging purpose as the gdb will point to the
line in the original source file, but also will make the
generated c code little more easy to decode while reading.