### PR TITLE
Building LLVM-CBE with the system LLVM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,15 @@
+if (USE_SYSTEM_LLVM)
+  cmake_minimum_required(VERSION 3.4.3)
+  find_package(LLVM REQUIRED CONFIG)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  include_directories(${LLVM_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(tools)
 

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -15,7 +15,6 @@
 #include "CBackend.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/TargetLowering.h"
-#include "llvm/Config/config.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/IR/DebugInfoMetadata.h"

--- a/tools/llvm-cbe/CMakeLists.txt
+++ b/tools/llvm-cbe/CMakeLists.txt
@@ -1,26 +1,39 @@
 # Support plugins.
 set(LLVM_NO_DEAD_STRIP 1)
 
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Analysis
-  AsmParser
-  AsmPrinter
-  BitReader
-  CBackendCodeGen
-  CBackendInfo
-  CodeGen
-  Core
-  IRReader
-  MC
-  ScalarOpts
-  SelectionDAG
-  Support
-  Target
-  )
+if (NOT USE_SYSTEM_LLVM)
+  set(LLVM_LINK_COMPONENTS
+    ${LLVM_TARGETS_TO_BUILD}
+    Analysis
+    AsmParser
+    AsmPrinter
+    BitReader
+    CBackendCodeGen
+    CBackendInfo
+    CodeGen
+    Core
+    IRReader
+    MC
+    ScalarOpts
+    SelectionDAG
+    Support
+    Target
+    )
 
 
-add_llvm_tool(llvm-cbe
-  llvm-cbe.cpp
-  )
-export_executable_symbols(llvm-cbe)
+  add_llvm_tool(llvm-cbe
+    llvm-cbe.cpp
+    )
+  export_executable_symbols(llvm-cbe)
+endif()
+
+if(USE_SYSTEM_LLVM)
+  add_executable(llvm-cbe
+    llvm-cbe.cpp
+    )
+  llvm_map_components_to_libnames(llvm_libs
+    CBackendCodeGen
+    CBackendInfo
+    )
+  target_link_libraries(llvm-cbe LLVM ${llvm_libs})
+endif()


### PR DESCRIPTION
This pull request adds a USE_SYSTEM_LLVM flag.

Tested on CentOS 8 with LLVM 7.

This allows to just git clone and build this repository without building LLVM in the process, with just adding the -DUSE_SYSTEM_LLVM=1 option to CMake.