### PR TITLE
GEP: Step the IntoT type when consuming operands to GEP

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -5040,6 +5040,7 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
     // First index isn't simple, print it the hard way.
     writeOperand(Ptr);
   } else {
+    IntoT = I.getIndexedType();
     ++I; // Skip the zero index.
 
     // Okay, emit the first operand. If Ptr is something that is already address
@@ -5051,6 +5052,7 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
       // P->f instead of "P[0].f"
       writeOperand(Ptr);
       Out << "->field" << cast<ConstantInt>(I.getOperand())->getZExtValue();
+      IntoT = I.getIndexedType();
       ++I; // eat the struct index as well.
     } else {
       // Instead of emitting P[0][1], emit (*P)[1], which is more idiomatic.


### PR DESCRIPTION
This fixes https://github.com/JuliaComputing/llvm-cbe/issues/52