### PR TITLE
Adds call to emit llvm_fcmp_uno and llvm_fcmp_ord

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -2547,8 +2547,8 @@ void CWriter::generateHeader(Module &M) {
     Out << "static __forceinline ";
     printTypeName(Out, RTy, isSigned);
     const auto Pred = (*it).first;
-    if (CmpInst::isFPPredicate((*it).first)) {
-      FCmpOps.insert(Pred);
+    if (CmpInst::isFPPredicate(Pred)) {
+      headerUseFCmpOp(Pred);
       Out << " llvm_fcmp_";
     } else
       Out << " llvm_icmp_";


### PR DESCRIPTION
Not entirely sure the call is placed in the correct place, but it solved my problem with llvm_fcmp_uno not being emitted (when llvm_fcmp_uge was):

```
src/CMakeFiles/llvm_cbe_poc.dir/code.cbe.c:47:79: warning: implicit declaration of function 'llvm_fcmp_uno' is invalid in C99 [-Wimplicit-function-declaration]
static __forceinline int llvm_fcmp_uge(double X, double Y) { return X >= Y || llvm_fcmp_uno(X, Y); }
```