### PR TITLE
Add option to declare locals at first assignment (C99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ main.c main.ll
 $ $(HOME)/llvm/build/bin/llvm-cbe main.ll
 ```
 
+You can find options to configure the C backend's output with `llvm-cbe --help`.
+Look for options beginning with `--cbe-`.
+
 Compile Generated C Code and Run
 ================================
 

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -60,6 +60,13 @@ namespace llvm_cbe {
 
 using namespace llvm;
 
+static cl::opt<bool> DeclareLocalsLate(
+  "cbe-declare-locals-late",
+  cl::desc(
+    "C backend: Declare local variables at the point they're first assigned, "
+    "if possible, rather than always at the start of the function. Note that "
+    "this is not legal in standard C prior to C99."));
+
 extern "C" void LLVMInitializeCBackendTarget() {
   // Register the target.
   RegisterTargetMachine<CTargetMachine> X(TheCBackendTarget);
@@ -3453,6 +3460,21 @@ static inline bool isFPIntBitCast(Instruction &I) {
          (DstTy->isFloatingPointTy() && SrcTy->isIntegerTy());
 }
 
+bool CWriter::canDeclareLocalLate(Instruction &I) {
+  if (!DeclareLocalsLate) {
+    return false;
+  }
+
+  // When a late declaration ends up inside a deeper scope than one of its uses,
+  // the C compiler will reject it. That doesn't happen if we restrict to a
+  // single block.
+  if (I.isUsedOutsideOfBlock(I.getParent())) {
+    return false;
+  }
+
+  return true;
+}
+
 void CWriter::printFunction(Function &F) {
   /// isStructReturn - Should this function actually return a struct by-value?
   bool isStructReturn = F.hasStructRetAttr();
@@ -3505,9 +3527,11 @@ void CWriter::printFunction(Function &F) {
       Out << ";    /* Address-exposed local */\n";
       PrintedVar = true;
     } else if (!isEmptyType(I->getType()) && !isInlinableInst(*I)) {
-      Out << "  ";
-      printTypeName(Out, I->getType(), false) << ' ' << GetValueName(&*I);
-      Out << ";\n";
+      if (!canDeclareLocalLate(*I)) {
+        Out << "  ";
+        printTypeName(Out, I->getType(), false) << ' ' << GetValueName(&*I);
+        Out << ";\n";
+      }
 
       if (isa<PHINode>(*I)) { // Print out PHI node temporaries as well...
         Out << "  ";
@@ -3560,7 +3584,6 @@ void CWriter::printLoop(Loop *L) {
 }
 
 void CWriter::printBasicBlock(BasicBlock *BB) {
-
   // Don't print the label for the basic block if there are no uses, or if
   // the only terminator use is the predecessor basic block's terminator.
   // We have to scan the use list because PHI nodes use basic blocks too but
@@ -3572,8 +3595,16 @@ void CWriter::printBasicBlock(BasicBlock *BB) {
       break;
     }
 
-  if (NeedsLabel)
-    Out << GetValueName(BB) << ":\n";
+  if (NeedsLabel) {
+    Out << GetValueName(BB) << ":";
+    // A label immediately before a late variable declaration is problematic,
+    // because "a label can only be part of a statement and a declaration is not
+    // a statement" (GCC). Adding a ";" is a simple workaround.
+    if (DeclareLocalsLate){
+      Out << ";";
+    }
+    Out << "\n";
+  }
 
   // Output all of the instructions in the basic block...
   for (BasicBlock::iterator II = BB->begin(), E = --BB->end(); II != E; ++II) {
@@ -3583,11 +3614,13 @@ void CWriter::printBasicBlock(BasicBlock *BB) {
       LastAnnotatedSourceLine = Loc->getLine();
     }
     if (!isInlinableInst(*II) && !isDirectAlloca(&*II)) {
-      if (!isEmptyType(II->getType()) && !isInlineAsm(*II))
-        outputLValue(&*II);
-
-      else
-        Out << "  ";
+      Out << "  ";
+      if (!isEmptyType(II->getType()) && !isInlineAsm(*II)) {
+        if (canDeclareLocalLate(*II)) {
+          printTypeName(Out, II->getType(), false) << ' ';
+        }
+        Out << GetValueName(&*II) << " = ";
+      }
       writeInstComputationInline(*II);
       Out << ";\n";
     }

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -310,11 +310,10 @@ private:
     errorWithMessage("unsupported LLVM instruction");
   }
 
-  void outputLValue(Instruction *I) { Out << "  " << GetValueName(I) << " = "; }
-
   LLVM_ATTRIBUTE_NORETURN void errorWithMessage(const char *message);
 
   bool isGotoCodeNecessary(BasicBlock *From, BasicBlock *To);
+  bool canDeclareLocalLate(Instruction &I);
   void printPHICopiesForSuccessor(BasicBlock *CurBlock, BasicBlock *Successor,
                                   unsigned Indent);
   void printBranchToBlock(BasicBlock *CurBlock, BasicBlock *SuccBlock,

--- a/test/test_cbe.py
+++ b/test/test_cbe.py
@@ -18,6 +18,10 @@ LLVM_TOOL_DIR = os.environ.get(
 LLVM_CBE_PATH = os.path.join(LLVM_TOOL_DIR, 'llvm-cbe')
 LLI_PATH = 'lli'
 
+CBE_FLAGS = [
+    # Harder to get right than early declarations, so more value to test it.
+    '-cbe-declare-locals-late',
+]
 
 COMMON_CFLAGS = [
     '-Iinclude/',
@@ -106,7 +110,7 @@ def compile_to_ir(c_filename, ir_filename, flags=None, cplusplus=False):
 
 
 def run_llvm_cbe(ir_filename, c_filename):
-    check_no_output([LLVM_CBE_PATH, ir_filename, '-o', c_filename])
+    check_no_output([LLVM_CBE_PATH, ir_filename, *CBE_FLAGS, '-o', c_filename])
     return c_filename
 
 


### PR DESCRIPTION
I think it reduces verbosity and improves readability. I've made it an option because it might not be to everyone's taste, and also this breaks pure C89 support, though I suspect this is available as an extension in many non-C99 compilers.

Example output without the change:

```c
static uint32_t factorial(uint32_t llvm_cbe_tmp__8) {
  uint32_t llvm_cbe_tmp__9;
  uint32_t llvm_cbe_tmp__10;
  uint32_t llvm_cbe_tmp__11;
  uint32_t llvm_cbe_tmp__11__PHI_TEMPORARY;

  if ((((((int32_t)llvm_cbe_tmp__8) > ((int32_t)1u))&1))) {
    goto llvm_cbe_tmp__12;
  } else {
    llvm_cbe_tmp__11__PHI_TEMPORARY = llvm_cbe_tmp__8;   /* for PHI node */
    goto llvm_cbe_tmp__13;
  }

llvm_cbe_tmp__12:
  llvm_cbe_tmp__9 = factorial((llvm_add_u32(llvm_cbe_tmp__8, -1)));
  llvm_cbe_tmp__10 = llvm_mul_u32(llvm_cbe_tmp__9, llvm_cbe_tmp__8);
  llvm_cbe_tmp__11__PHI_TEMPORARY = llvm_cbe_tmp__10;   /* for PHI node */
  goto llvm_cbe_tmp__13;

llvm_cbe_tmp__13:
  llvm_cbe_tmp__11 = llvm_cbe_tmp__11__PHI_TEMPORARY;
  return llvm_cbe_tmp__11;
}
```

Example with the change:

```c
static uint32_t factorial(uint32_t llvm_cbe_tmp__8) {
  uint32_t llvm_cbe_tmp__9__PHI_TEMPORARY;

  if ((((((int32_t)llvm_cbe_tmp__8) > ((int32_t)1u))&1))) {
    goto llvm_cbe_tmp__10;
  } else {
    llvm_cbe_tmp__9__PHI_TEMPORARY = llvm_cbe_tmp__8;   /* for PHI node */
    goto llvm_cbe_tmp__11;
  }

llvm_cbe_tmp__10:;
  uint32_t llvm_cbe_tmp__12 = factorial((llvm_add_u32(llvm_cbe_tmp__8, -1)));
  uint32_t llvm_cbe_tmp__13 = llvm_mul_u32(llvm_cbe_tmp__12, llvm_cbe_tmp__8);
  llvm_cbe_tmp__9__PHI_TEMPORARY = llvm_cbe_tmp__13;   /* for PHI node */
  goto llvm_cbe_tmp__11;

llvm_cbe_tmp__11:;
  uint32_t llvm_cbe_tmp__9 = llvm_cbe_tmp__9__PHI_TEMPORARY;
  return llvm_cbe_tmp__9;
}
```

It looks even better with https://github.com/JuliaComputing/llvm-cbe/pull/95:

```c
static uint32_t factorial(uint32_t _8) {
  uint32_t _9__PHI_TEMPORARY;

  if ((((((int32_t)_8) > ((int32_t)1u))&1))) {
    goto _10;
  } else {
    _9__PHI_TEMPORARY = _8;   /* for PHI node */
    goto _11;
  }

_10:;
  uint32_t _12 = factorial((llvm_add_u32(_8, -1)));
  uint32_t _13 = llvm_mul_u32(_12, _8);
  _9__PHI_TEMPORARY = _13;   /* for PHI node */
  goto _11;

_11:;
  uint32_t _9 = _9__PHI_TEMPORARY;
  return _9;
}
```

Of course, this is quite simple code. (I chose it as an example because it's reasonably short.) In practice, the benefit is of course particularly pronounced for large functions with many instructions.