### PR TITLE
Use shorter local names like "_123" when possible

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -1524,7 +1524,14 @@ std::string CWriter::GetValueName(Value *Operand) {
   std::string Name = Operand->getName();
   if (Name.empty()) { // Assign unique names to local temporaries.
     unsigned No = AnonValueNumbers.getOrInsert(Operand);
-    Name = "tmp__" + utostr(No);
+
+    Name = "_" + utostr(No);
+    if (!TheModule->getNamedValue(Name)) {
+      // Short name for the common case where there's no conflicting global.
+      return Name;
+    }
+
+    Name = "tmp_" + Name;
   }
 
   // Mangle globals with the standard mangler interface for LLC compatibility.


### PR DESCRIPTION
Fixes #70.

Example output without the change:

```c
static uint32_t factorial(uint32_t llvm_cbe_tmp__8) {
  uint32_t llvm_cbe_tmp__9;
  uint32_t llvm_cbe_tmp__10;
  uint32_t llvm_cbe_tmp__11;
  uint32_t llvm_cbe_tmp__11__PHI_TEMPORARY;

  if ((((((int32_t)llvm_cbe_tmp__8) > ((int32_t)1u))&1))) {
    goto llvm_cbe_tmp__12;
  } else {
    llvm_cbe_tmp__11__PHI_TEMPORARY = llvm_cbe_tmp__8;   /* for PHI node */
    goto llvm_cbe_tmp__13;
  }

llvm_cbe_tmp__12:
  llvm_cbe_tmp__9 = factorial((llvm_add_u32(llvm_cbe_tmp__8, -1)));
  llvm_cbe_tmp__10 = llvm_mul_u32(llvm_cbe_tmp__9, llvm_cbe_tmp__8);
  llvm_cbe_tmp__11__PHI_TEMPORARY = llvm_cbe_tmp__10;   /* for PHI node */
  goto llvm_cbe_tmp__13;

llvm_cbe_tmp__13:
  llvm_cbe_tmp__11 = llvm_cbe_tmp__11__PHI_TEMPORARY;
  return llvm_cbe_tmp__11;
}
```

Example with the change:

```c
static uint32_t factorial(uint32_t _8) {
  uint32_t _9;
  uint32_t _10;
  uint32_t _11;
  uint32_t _11__PHI_TEMPORARY;

  if ((((((int32_t)_8) > ((int32_t)1u))&1))) {
    goto _12;
  } else {
    _11__PHI_TEMPORARY = _8;   /* for PHI node */
    goto _13;
  }

_12:
  _9 = factorial((llvm_add_u32(_8, -1)));
  _10 = llvm_mul_u32(_9, _8);
  _11__PHI_TEMPORARY = _10;   /* for PHI node */
  goto _13;

_13:
  _11 = _11__PHI_TEMPORARY;
  return _11;
}
```

It looks even better with https://github.com/JuliaComputing/llvm-cbe/pull/94:

```c
static uint32_t factorial(uint32_t _8) {
  uint32_t _9__PHI_TEMPORARY;

  if ((((((int32_t)_8) > ((int32_t)1u))&1))) {
    goto _10;
  } else {
    _9__PHI_TEMPORARY = _8;   /* for PHI node */
    goto _11;
  }

_10:;
  uint32_t _12 = factorial((llvm_add_u32(_8, -1)));
  uint32_t _13 = llvm_mul_u32(_12, _8);
  _9__PHI_TEMPORARY = _13;   /* for PHI node */
  goto _11;

_11:;
  uint32_t _9 = _9__PHI_TEMPORARY;
  return _9;
}
```

Of course, this is quite simple code. (I chose it as an example because it's reasonably short.) In practice, the benefit is of course particularly pronounced for larger and more complex functions, especially ones with long inlined (single-line) expressions.