### PR TITLE
Add support for LLVM 8+'s FNEG (fixes #90)

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3784,6 +3784,47 @@ void CWriter::visitPHINode(PHINode &I) {
   Out << "__PHI_TEMPORARY";
 }
 
+void CWriter::visitUnaryOperator(UnaryOperator &I) {
+  CurInstr = &I;
+
+  // Currently the only unary operator supported is FNeg, which was introduced
+  // in LLVM 8, although not fully exploited until later LLVM versions.
+  // Older code uses a pseudo-FNeg pattern (-0.0 - x) which is matched in
+  // visitBinaryOperator instead.
+  if (I.getOpcode() != Instruction::FNeg) {
+    DBG_ERRS("Invalid operator type !" << I);
+    errorWithMessage("invalid operator type");
+  }
+
+  Value *X = I.getOperand(0);
+
+  // We must cast the results of operations which might be promoted.
+  bool needsCast = false;
+  if ((I.getType() == Type::getInt8Ty(I.getContext())) ||
+      (I.getType() == Type::getInt16Ty(I.getContext())) ||
+      (I.getType() == Type::getFloatTy(I.getContext()))) {
+    // types too small to work with directly
+    needsCast = true;
+  } else if (I.getType()->getPrimitiveSizeInBits() > 64) {
+    // types too big to work with directly
+    needsCast = true;
+  }
+
+  if (I.getType()->isVectorTy() || needsCast) {
+    Type *VTy = I.getOperand(0)->getType();
+    Out << "llvm_neg_";
+    printTypeString(Out, VTy, false);
+    Out << "(";
+    writeOperand(X, ContextCasted);
+    Out << ")";
+    InlineOpDeclTypes.insert(std::pair<unsigned, Type *>(BinaryNeg, VTy));
+  } else {
+    Out << "-(";
+    writeOperand(X);
+    Out << ")";
+  }
+}
+
 void CWriter::visitBinaryOperator(BinaryOperator &I) {
   using namespace PatternMatch;
 

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -281,6 +281,7 @@ private:
   void visitUnreachableInst(UnreachableInst &I);
 
   void visitPHINode(PHINode &I);
+  void visitUnaryOperator(UnaryOperator &I);
   void visitBinaryOperator(BinaryOperator &I);
   void visitICmpInst(ICmpInst &I);
   void visitFCmpInst(FCmpInst &I);


### PR DESCRIPTION
I've tested it with LLVM 10.0.0 and a simple C program:

```c
#include <stdlib.h>
#include <stdio.h>
      
int main(int argc, char **argv)
{     
    double d = strtod(argv[1], NULL);
    printf("%f\n", -d);
    float f = strtod(argv[1], NULL);
    printf("%f\n", -f);
    long double ld = strtold(argv[1], NULL);
    printf("%Lf\n", -ld);
} 
```

It doesn't seem worth adding a test for this, but if there's a desire for one I'm sure I can add it.
