### PR TITLE
Reformatted with clang-format 11.0.1

### DIFF
--- a/lib/Target/CBackend/CTargetMachine.h
+++ b/lib/Target/CBackend/CTargetMachine.h
@@ -41,7 +41,8 @@ public:
                             ArrayRef<SubtargetFeatureKV>(), nullptr, nullptr,
                             nullptr, nullptr, nullptr, nullptr, nullptr),
 #endif
-        Lowering(TM) {}
+        Lowering(TM) {
+  }
   bool enableAtomicExpand() const override;
   const TargetLowering *getTargetLowering() const override;
   const CTargetLowering Lowering;
@@ -70,7 +71,7 @@ public:
 #else
                            MachineModuleInfo *MMI = nullptr
 #endif
-			  ) override;
+                           ) override;
 
   // TargetMachine interface
   const TargetSubtargetInfo *getSubtargetImpl(const Function &) const override;


### PR DESCRIPTION
    clang-format -i `find lib/ unittests/ -name \*.h -or -name \*.cpp`

Some of the things cleaned up are my fault. Sorry about that.